### PR TITLE
Configure Quarto for no theme and minimal HTML

### DIFF
--- a/nbs/_quarto.yml
+++ b/nbs/_quarto.yml
@@ -3,7 +3,8 @@ project:
 
 format:
   html:
-    theme: cosmo
+    minimal: true
+    theme: none
     css: https://cdn.jsdelivr.net/npm/fomantic-ui@2.9.3/dist/semantic.min.css
     toc: true
 


### PR DESCRIPTION
⚠️ Don't merge yet
This PR configures Quarto so all Bootstrap classes are removed, as far as I can tell. It loses the sidebar, though!

To do:

- [ ] Sidebar `style: floating` or `style: docked` don't bring the sidebar back. How do we get it back?
- [ ] Put the main text of each docs page into a container for better display, ideally without tying it to one specific CSS framework. That way similar libraries can be created without having to each create a custom Quarto theme.